### PR TITLE
Install script was missing the ecto setup step

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -3,6 +3,10 @@
 set -e
 DIR=$(pwd -P)
 mix deps.get && mix compile
-cd "$DIR/apps/interface"
+
+(cd "$DIR/apps/domain"
+mix ecto.reset)
+
+(cd "$DIR/apps/interface"
 npm install
-node_modules/protractor/bin/webdriver-manager update
+node_modules/protractor/bin/webdriver-manager update)


### PR DESCRIPTION
Fix for #4, must have been broken in recent umbrella refactor.