### PR TITLE
fix warnings about parenthesis in mix.exs

### DIFF
--- a/apps/domain/mix.exs
+++ b/apps/domain/mix.exs
@@ -11,8 +11,8 @@ defmodule Domain.Mixfile do
      elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     aliases: aliases,
-     deps: deps]
+     aliases: aliases(),
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/apps/interface/mix.exs
+++ b/apps/interface/mix.exs
@@ -13,8 +13,8 @@ defmodule Interface.Mixfile do
      compilers: [:phoenix, :gettext] ++ Mix.compilers,
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     aliases: aliases,
-     deps: deps]
+     aliases: aliases(),
+     deps: deps()]
   end
 
   # Configuration for the OTP application.

--- a/mix.exs
+++ b/mix.exs
@@ -5,8 +5,8 @@ defmodule Umb.Mixfile do
     [apps_path: "apps",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
-     aliases: aliases]
+     deps: deps(),
+     aliases: aliases()]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
Elixir 1.4 issues warnings about calling functions without arguments without parenthesis.  This fixes that.